### PR TITLE
ensure the credential state is unique wihtin one service

### DIFF
--- a/src/tts_credential.erl
+++ b/src/tts_credential.erl
@@ -98,16 +98,22 @@ revoke(CredentialId, UserInfo) ->
 handle_request_result({ok, #{error := Error}, Log}, _ServiceId, _UserInfo,
                       _Interface, _Token) ->
     return_error_with_debug({script, Error}, Log);
-handle_request_result({ok, #{credential := Cred} = CredMap , Log}
+handle_request_result({ok, #{credential := Cred, state := CredState}, Log}
                       , ServiceId, #{site := #{uid := UserId}} = UserInfo,
                       Interface, _Token) ->
-    CredState = maps:get(state, CredMap, <<"">>),
-    {ok, CredId} = sync_store_credential(UserId, ServiceId, Interface,
-                                         CredState),
-    lager:info("New Credential ~p [~p] at service ~p for ~p using ~p",
-               [CredId, CredState, ServiceId, UserInfo, Interface]),
-    Id = #{name => id, type => text, value => CredId},
-    return_result_with_debug([ Id | Cred], Log);
+    case sync_store_credential(UserId, ServiceId, Interface, CredState) of
+        {ok, CredId} ->
+            lager:info("New Credential ~p [~p] at service ~p for ~p using ~p",
+                       [CredId, CredState, ServiceId, UserInfo, Interface]),
+            Id = #{name => id, type => text, value => CredId},
+            return_result_with_debug([ Id | Cred], Log);
+        Error ->
+            return_error_with_debug({storing, Error}, Log)
+    end;
+handle_request_result({ok, #{credential := _Cred}, Log} , ServiceId, UserInfo,
+                      _Interface, _Token) ->
+    lager:critical("missing state in service ~p for ~p", [ServiceId, UserInfo]),
+    return_error_with_debug({missing_state, ServiceId}, Log);
 handle_request_result({error, Error, Log}, _ServiceId, _UserInfo, _Interface,
                       _Token) ->
     return_error_with_debug({internal, Error}, Log);
@@ -155,9 +161,9 @@ init([]) ->
 
 handle_call({store_credential, UserId, ServiceId, Interface, CredState}, _From,
             State) ->
-    {ok, CredentialId} = store_credential(UserId, ServiceId, Interface,
+    Result = store_credential(UserId, ServiceId, Interface,
                                           CredState),
-    {reply, {ok, CredentialId}, State};
+    {reply, Result, State};
 handle_call(_Request, _From, State) ->
     {reply, ignored, State}.
 
@@ -198,8 +204,9 @@ get_credential_list(UserId) ->
     tts_data_sqlite:credential_get_list(UserId).
 
 store_credential(UserId, ServiceId, Interface, CredentialState) ->
+    SameStateAllowed = tts_service:allows_same_state(ServiceId),
     tts_data_sqlite:credential_add(UserId, ServiceId, Interface,
-                                   CredentialState).
+                                   CredentialState, SameStateAllowed).
 
 remove_credential(UserId, CredentialId) ->
     tts_data_sqlite:credential_remove(UserId, CredentialId).

--- a/src/tts_data_sqlite.erl
+++ b/src/tts_data_sqlite.erl
@@ -21,7 +21,7 @@
 %% API.
 -export([start_link/0]).
 -export([reconfigure/0]).
--export([credential_add/4]).
+-export([credential_add/5]).
 -export([credential_get/1]).
 -export([credential_get_list/1]).
 -export([credential_get_count/2]).
@@ -51,11 +51,12 @@ reconfigure() ->
     gen_server:cast(?MODULE, reconfigure).
 
 -spec credential_add(UserId::binary(), ServiceId::binary(),
-                     Interface ::binary(), CredState :: any())
+                     Interface ::binary(), CredState :: any(),
+                     AllowNonUniqueStates::boolean())
 -> ok | {error, Reason :: atom()}.
-credential_add(UserId, ServiceId, Interface, CredState) ->
+credential_add(UserId, ServiceId, Interface, CredState, SameStateAllowed) ->
     gen_server:call(?MODULE, {credential_add, UserId, ServiceId, Interface,
-                              CredState}).
+                              CredState, SameStateAllowed}).
 
 -spec credential_get_list(UserId::binary()) -> [tts:cred()].
 credential_get_list(UserId) ->
@@ -81,9 +82,10 @@ init([]) ->
 
 handle_call(_, _From, #state{con=undefined}=State) ->
     {reply, {error, not_configured}, State};
-handle_call({credential_add, UserId, ServiceId, Interface, CredState}, _From
-            , #state{con=Con}=State) ->
-    Result = credential_add(UserId, ServiceId, Interface, CredState, Con),
+handle_call({credential_add, UserId, ServiceId, Interface, CredState,
+             SameStateAllowed}, _From , #state{con=Con}=State) ->
+    Result = credential_add(UserId, ServiceId, Interface, CredState,
+                            SameStateAllowed, Con),
     {reply, Result, State};
 handle_call({credential_get_list, UserId}, _From, #state{con=Con}=State) ->
     CredList = credential_get_list(UserId, Con),
@@ -121,15 +123,28 @@ code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
 
 
-credential_add(UserId, ServiceId, Interface, CredState, Con) ->
+credential_add(UserId, ServiceId, Interface, CredState, SameStateOk, Con) ->
     ok = esqlite3:exec("begin;", Con),
-    CredentialId = create_random_credential_id(Con),
-    CreationTime = erlang:system_time(seconds),
-    esqlite3:q("INSERT INTO tts_cred VALUES( ?1, ?2, ?3, ?4, ?5, ?6);"
-               , [CredentialId, CreationTime, Interface, UserId, ServiceId,
-                  CredState] , Con),
+    {Unique, CredId}=credential_state_unique(UserId, ServiceId, CredState, Con),
+    Result = case (Unique) of
+                 true ->
+                     CredentialId = create_random_credential_id(Con),
+                     CreationTime = erlang:system_time(seconds),
+                     esqlite3:q("INSERT INTO tts_cred
+                                VALUES( ?1,?2,?3,?4,?5,?6);",
+                                [CredentialId, CreationTime, Interface, UserId,
+                                 ServiceId, CredState] , Con),
+                     {ok, CredentialId};
+                 false ->
+                     case SameStateOk of
+                         true ->
+                             {ok, CredId};
+                         _ ->
+                             {error, not_unique_state}
+                     end
+             end,
     ok = esqlite3:exec("commit;", Con),
-    {ok, CredentialId}.
+    Result.
 
 
 credential_get_list(UserId, Con) ->
@@ -165,6 +180,17 @@ credential_get(CredId, Con) ->
         [Cred] -> {ok, ToCred(Cred)}
     end.
 
+credential_state_unique(UserId, ServiceId, CredState, Con) ->
+    Result = esqlite3:q("SELECT credential_id FROM tts_cred
+                         WHERE user_id IS ?1 AND service_id IS ?2
+                         AND credstate IS ?3"
+                          , [UserId, ServiceId, CredState], Con),
+    case Result of
+        [] -> {true, none};
+        [{CredId}] -> {false, CredId}
+    end.
+
+
 credential_remove(UserId, CredentialId, Con) ->
     ok = esqlite3:exec("begin;", Con),
     esqlite3:q("DELETE FROM tts_cred WHERE user_id=?1 AND credential_id=?2;",
@@ -195,7 +221,11 @@ reconfigure(#state{con=Con} = State) ->
                   <<"tts_cred">>,
                   <<"CREATE TABLE tts_cred(credential_id Text, ctime INTEGER,
                   interface TEXT, user_id TEXT, service_id TEXT,
-                    credstate TEXT)">>}
+                    credstate TEXT);
+                    CREATE INDEX tts_cred_user_idx ON tts_cred(user_id);
+                    CREATE INDEX tts_cred_service_idx ON tts_cred(service_id);
+                    CREATE INDEX tts_cred_state_idx ON tts_cred(credstate);
+                    ">>}
                 ]).
 
 create_tables_if_needed(Con) ->

--- a/src/tts_service.erl
+++ b/src/tts_service.erl
@@ -144,7 +144,8 @@ map_to_atom_keys([{Key, Value}|T], Map) when is_list(Key) ->
                     {<<"local">>, local},
                     {<<"none">>, local},
 
-                    {<<"undefined">>, undefined}
+                    {<<"undefined">>, undefined},
+                    {<<"true">>, true}
                    ]).
 
 bin_to_atom(BinaryKey) ->
@@ -179,6 +180,8 @@ verify_value(AKey, Value) when is_list(Value) ->
     verify_value(AKey, list_to_binary(Value));
 verify_value(con_type, Value) ->
     {ok, bin_to_atom(Value, undefined)};
+verify_value(allow_same_state, Value) ->
+    {ok, bin_to_atom(Value, false)};
 verify_value(_AKey, Value) ->
     {ok, Value}.
 

--- a/src/tts_service.erl
+++ b/src/tts_service.erl
@@ -25,6 +25,7 @@
 -export([disable/1]).
 -export([enable/1]).
 -export([is_enabled/1]).
+-export([allows_same_state/1]).
 -export([get_credential_limit/1]).
 
 get_list() ->
@@ -61,11 +62,15 @@ get_credential_limit(ServiceId) ->
         _ -> {ok, 0}
     end.
 
-
-
 is_enabled(ServiceId) ->
     case tts_data:service_get(ServiceId) of
-        {ok, {_Id, Info}} -> maps:get(enabled, Info, true);
+        {ok, {_Id, Info}} -> maps:get(enabled, Info, false);
+        _ -> false
+    end.
+
+allows_same_state(ServiceId) ->
+    case tts_data:service_get(ServiceId) of
+        {ok, {_Id, Info}} -> maps:get(allow_same_state, Info, false);
         _ -> false
     end.
 
@@ -129,6 +134,8 @@ map_to_atom_keys([{Key, Value}|T], Map) when is_list(Key) ->
                     {<<"ConnectionHost">>, con_host},
                     {<<"ConnectionPort">>, con_port},
                     {<<"ConnectionSshDir">>, con_ssh_user_dir},
+
+                    {<<"AllowSameState">>, allow_same_state},
 
                     {<<"Cmd">>, cmd},
 


### PR DESCRIPTION
the same state can be returned, which is used for the same credential.
This must be enabled by setting a configuration in the service conf: AllowSameState = true
