### PR TITLE
update oidcc which fixes and OpenId Connect issue

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -4,7 +4,7 @@
            ]}.
 
 {deps, [
-        {oidcc, {git, "https://github.com/indigo-dc/oidcc.git", {ref, "e8d5543"}}},
+        {oidcc, {git, "https://github.com/indigo-dc/oidcc.git", {ref, "b79bf17"}}},
 
         {node_package, {git, "https://github.com/dergraf/node_package.git", {branch, "rebar3-support"}}},
 


### PR DESCRIPTION
enables the TTS to be used by the OpenID Connect provider by Human Brain Project (HBP)
