### PR TITLE
fix multiple cerificates with same subject

### DIFF
--- a/tts_config/plugins/x509.py
+++ b/tts_config/plugins/x509.py
@@ -164,6 +164,9 @@ def init_ca():
     Cmd = "touch %s/index.txt > /dev/null"%(AbsBase)
     if os.system(Cmd) != 0:
         return json.dumps({'error':'touch_failed'})
+    Cmd = "echo \"unique_subject = no\" > %s/index.txt.attr"%(AbsBase)
+    if os.system(Cmd) != 0:
+        return json.dumps({'error':'index.attr_failed'})
     Cmd = "echo \"01\" > %s/serial"%(AbsBase)
     if os.system(Cmd) != 0:
         return json.dumps({'error':'serial_failed'})


### PR DESCRIPTION
add line 'unique_subject = no' in index.txt.attr to fix multiple cerificates with same subject
