### PR TITLE
ensure the pipe_dir is set

### DIFF
--- a/config/vars.config
+++ b/config/vars.config
@@ -26,6 +26,7 @@
 {runner_user,           ""}.
 {runner_wait_process,   "tts_temp_cred"}.
 {runner_ulimit_warn,    1}.
+{pipe_dir,              "$RUNNER_BASE_DIR/pipe"}.
 
 
 {cuttlefish, "on"}.


### PR DESCRIPTION
this is used to start tts during development without a console.