### PR TITLE
Fix #229

### DIFF
--- a/config/schema/tts.schema
+++ b/config/schema/tts.schema
@@ -129,6 +129,14 @@
           {commented, 8080}
           ]}.
 
+%% @doc if a service id is not configured by default the user is
+%% unable to revoke credentials of that service, by setting this to true
+%% all credentials of unconfigured services can be revoked
+{mapping, "allow_dropping_credentials", "tts.allow_dropping_credentials", [
+          {datatype ,    {enum ,  [true, false]}},
+          {default, false}
+          ]}.
+
 {mapping, "debug_mode", "tts.debug_mode", [
           hidden,
           {datatype ,    {enum ,  [true, false]}},

--- a/src/tts_service.erl
+++ b/src/tts_service.erl
@@ -23,6 +23,7 @@
 -export([add/1]).
 -export([update_params/1]).
 
+-export([exists/1]).
 -export([is_enabled/1]).
 -export([is_allowed/2]).
 -export([allows_same_state/1]).
@@ -63,6 +64,16 @@ get_credential_limit(ServiceId) ->
         {ok, {_Id, Info}} -> {ok, maps:get(cred_limit, Info, 0)};
         _ -> {ok, 0}
     end.
+
+
+exists(ServiceId) ->
+    case tts_data:service_get(ServiceId) of
+        {ok, _} ->
+            true;
+        _ ->
+            false
+     end.
+
 
 get_queue(ServiceId) ->
     case tts_data:service_get(ServiceId) of


### PR DESCRIPTION
revocation of a deprecated service is now possible, if the new
configuration 'allow_dropping_credentials' is set to 'true'