### PR TITLE
add possibility to pass access token to plugin

### DIFF
--- a/config/schema/service.schema
+++ b/config/schema/service.schema
@@ -24,47 +24,53 @@
           {datatype, [{atom, true}, {atom, false}]}
           ]}.
 
+%% @doc if enabled the plugin will get the access token, use this
+%% option with caution! default is 'false'
+{mapping, "service.$id.pass_access_token", "tts.service_list.e", [
+          {datatype, [{atom, true}, {atom, false}]}
+          ]}.
+
 %% @doc the way tts connects to the place where to start the plugin
 %% this can be either local or ssh
 %% @see service.$id.cmd
-{mapping, "service.$id.connection.type", "tts.service_list.e", [
+{mapping, "service.$id.connection.type", "tts.service_list.f", [
           {datatype, {enum, [local, ssh]}}
           ]}.
 
 %% @doc the username to use for the connection
-{mapping, "service.$id.connection.user", "tts.service_list.e", [
+{mapping, "service.$id.connection.user", "tts.service_list.g", [
           {datatype, string}
           ]}.
 
 %% @doc the password to use for the connection
-{mapping, "service.$id.connection.password", "tts.service_list.g", [
+{mapping, "service.$id.connection.password", "tts.service_list.h", [
           {datatype, string}
           ]}.
 
 %% @doc the host to connect to
-{mapping, "service.$id.connection.host", "tts.service_list.h", [
+{mapping, "service.$id.connection.host", "tts.service_list.i", [
           {datatype, string}
           ]}.
 
 %% @doc the port to connect to
-{mapping, "service.$id.connection.port", "tts.service_list.i", [
+{mapping, "service.$id.connection.port", "tts.service_list.j", [
           {datatype, integer}
           ]}.
 
 
 %% @doc the sshDir to use when connecting
-{mapping, "service.$id.connection.ssh_dir", "tts.service_list.j", [
+{mapping, "service.$id.connection.ssh_dir", "tts.service_list.k", [
           {datatype, string}
           ]}.
 
 
 %% @doc the password for the ssh private key
-{mapping, "service.$id.connection.ssh_key_pass", "tts.service_list.k", [
+{mapping, "service.$id.connection.ssh_key_pass", "tts.service_list.l", [
           {datatype, string}
           ]}.
 
 %% @doc the plugin configuration parameter
-{mapping, "service.$id.plugin.$key", "tts.service_list.l", [
+{mapping, "service.$id.plugin.$key", "tts.service_list.m", [
           {datatype, string}
           ]}.
 
@@ -105,6 +111,7 @@
          CredLimits = TypeIdValue("service.$id.credential_limit", three),
          Runners = TypeIdValue("service.$id.parallel_runner", three),
          SameStates = TypeIdValue("service.$id.allow_same_state", three),
+         PassAccTokens = TypeIdValue("service.$id.pass_access_token", three),
          ConnTypes = TypeIdValue("service.$id.connection.type", four),
          ConnUsers = TypeIdValue("service.$id.connection.user", four),
          ConnPasswds = TypeIdValue("service.$id.connection.password", four),
@@ -143,6 +150,11 @@
                      SameState = case lists:keyfind(Id, 1, SameStates) of
                                      {Id, Allow}
                                             -> Allow;
+                                     _ -> false
+                                 end,
+                     PassAccToken = case lists:keyfind(Id, 1, PassAccTokens) of
+                                     {Id, PassAccessToken}
+                                            -> PassAccessToken;
                                      _ -> false
                                  end,
                      ConnType = case lists:keyfind(Id, 1, ConnTypes) of
@@ -212,6 +224,7 @@
                                   allow_same_state => SameState,
                                   plugin_conf_config => PluginConf,
                                   parallel_runner => ParaRunner,
+                                  pass_access_token => PassAccToken,
                                   connection => #{
                                     type => ConnType,
                                     user => ConnUser,

--- a/src/tts_session.erl
+++ b/src/tts_session.erl
@@ -176,11 +176,13 @@ handle_call({set_token, Token}, _From,
             #state{user_info=Info, max_age=MA}=State) ->
     IdInfo = maps:get(user_info, Token, #{}),
     IdToken = maps:get(id, Token, #{}),
+    AccessToken = maps:get(access, Token, #{}),
     {ok, Info1} = tts_userinfo:update_id_token(IdToken, Info),
     {ok, Info2} = tts_userinfo:update_id_info(IdInfo, Info1),
+    {ok, Info3} = tts_userinfo:update_access_token(AccessToken, Info2),
     TokenKeys = [access, id, refresh],
     TokenMap = maps:with(TokenKeys, Token),
-    {reply, ok, State#state{token=TokenMap, user_info=Info2}, MA};
+    {reply, ok, State#state{token=TokenMap, user_info=Info3}, MA};
 handle_call(get_token, _From, #state{max_age=MA, token=Token}=State) ->
     {reply, {ok, Token}, State, MA};
 handle_call({set_error, Error}, _From, #state{max_age=MA}=State) ->


### PR DESCRIPTION
the default is not to pass the access token, yet some plugins might need the access token themselfs.
it is enabled by setting the service parameter 'pass_access_token' to 'true'.
fix #233