### PR TITLE
Add archlinux support

### DIFF
--- a/utils/archlinux_install_packages.sh
+++ b/utils/archlinux_install_packages.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+sudo pacman -S base-devel wget openssl ncurses

--- a/utils/build_install_erlang.sh
+++ b/utils/build_install_erlang.sh
@@ -5,7 +5,7 @@ wget http://erlang.org/download/otp_src_$VERSION.tar.gz
 tar -xzf otp_src_$VERSION.tar.gz
 rm otp_src_$VERSION.tar.gz
 cd otp_src_$VERSION
-./configure --with-ssl
+./configure --with-ssl --enable-builtin-zlib
 make
 sudo make install
 cd ..

--- a/utils/prepare_system.sh
+++ b/utils/prepare_system.sh
@@ -15,6 +15,9 @@ case "$DISTRIBUTION_NAME" in
     *CentOS*)
         DISTRIBUTION="centos"
         ;;
+    *Arch\ Linux*)
+        DISTRIBUTION="archlinux"
+        ;;
 esac
 echo "preparing the system ..."
 echo "distribution: $DISTRIBUTION"
@@ -38,6 +41,9 @@ case "$DISTRIBUTION" in
         ;;
     centos)
         ./centos_install_packages.sh
+        ;;
+    archlinux)
+        ./archlinux_install_packages.sh
         ;;
 esac
 


### PR DESCRIPTION
I colud not build WaTTS on Archlinux. This helps.

We need to compile erlang with the builtin zlib, because Arch's zlib version is to high for erlang.
See: https://bugs.archlinux.org/task/52867